### PR TITLE
Add settings dialog and background color customization

### DIFF
--- a/src/main/frontend/src/html/callgraph.html
+++ b/src/main/frontend/src/html/callgraph.html
@@ -91,6 +91,7 @@
     </div>
     <button class="navbutton generatedGraphController hidden" onclick="fit()">FIT</button>
     <button class="navbutton generatedGraphController hidden" onclick="JavaBridge.saveAsHtml()">SAVE AS HTML</button>
+    <button class="navbutton" onclick="JavaBridge.openSettings()">OPTIONS</button>
 </div>
 <script defer="defer">
     <% /*

--- a/src/main/frontend/src/js/callgraph.js
+++ b/src/main/frontend/src/js/callgraph.js
@@ -7,6 +7,8 @@ window.JavaBridge = {
     saveAsHtml: (unused) => {
     },
     generateGraph: (unused) => {
+    },
+    openSettings: (unused) => {
     }
 }
 

--- a/src/main/java/callgraph/callgraph/browser/HandlerFactory.java
+++ b/src/main/java/callgraph/callgraph/browser/HandlerFactory.java
@@ -2,6 +2,7 @@ package callgraph.callgraph.browser;
 
 import callgraph.callgraph.browser.handlers.GenerateGraphHandler;
 import callgraph.callgraph.browser.handlers.GoToSourceHandler;
+import callgraph.callgraph.browser.handlers.OpenSettingsHandler;
 import callgraph.callgraph.browser.handlers.SaveAsHtmlHandler;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.jcef.JBCefBrowserBase;
@@ -15,6 +16,7 @@ public class HandlerFactory {
         handlers.add(new GenerateGraphHandler(browser, project));
         handlers.add(new GoToSourceHandler(browser, project));
         handlers.add(new SaveAsHtmlHandler(browser, project));
+        handlers.add(new OpenSettingsHandler(browser, project));
         return handlers;
     }
 }

--- a/src/main/java/callgraph/callgraph/browser/handlers/OpenSettingsHandler.java
+++ b/src/main/java/callgraph/callgraph/browser/handlers/OpenSettingsHandler.java
@@ -1,0 +1,47 @@
+package callgraph.callgraph.browser.handlers;
+
+import callgraph.callgraph.browser.JSQueryHandler;
+import callgraph.callgraph.settings.CallGraphSettingsDialog;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.jcef.JBCefBrowserBase;
+import com.intellij.ui.jcef.JBCefJSQuery;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+
+/**
+ * Handler for opening the settings dialog from the UI.
+ */
+public class OpenSettingsHandler extends JSQueryHandler {
+    public OpenSettingsHandler(JBCefBrowserBase browser, Project project) {
+        super(browser, project);
+    }
+
+    @Override
+    @NotNull
+    public Function<? super String, ? extends JBCefJSQuery.Response> getHandler() {
+        return unused -> {
+            ApplicationManager.getApplication().invokeLater(() -> {
+                CallGraphSettingsDialog dialog = new CallGraphSettingsDialog(project);
+                // Just show the dialog - changes are applied in real-time
+                // The dialog's doOKAction will save the final state
+                dialog.showAndGet();
+                // No need for additional update as changes are already applied
+            });
+            return null;
+        };
+    }
+
+    @Override
+    @NotNull
+    public String getHandlerName() {
+        return "openSettings";
+    }
+
+    @Override
+    @NotNull
+    public String getArgName() {
+        return "unused";
+    }
+}

--- a/src/main/java/callgraph/callgraph/browser/handlers/SaveAsHtmlHandler.java
+++ b/src/main/java/callgraph/callgraph/browser/handlers/SaveAsHtmlHandler.java
@@ -3,16 +3,20 @@ package callgraph.callgraph.browser.handlers;
 import callgraph.callgraph.CallGraphGenerator;
 import callgraph.callgraph.Utils;
 import callgraph.callgraph.browser.JSQueryHandler;
+import callgraph.callgraph.settings.CallGraphSettings;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.fileChooser.FileChooser;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiMethod;
+import com.intellij.ui.ColorUtil;
 import com.intellij.ui.jcef.JBCefBrowserBase;
 import com.intellij.ui.jcef.JBCefJSQuery;
 import org.jetbrains.annotations.NotNull;
+import java.awt.Color;
 
 import java.io.IOException;
 import java.util.function.Function;
@@ -35,7 +39,20 @@ public class SaveAsHtmlHandler extends JSQueryHandler {
                     String methodName = lastGeneratedMethod.getName();
                     String methodPath = className + "." + methodName;
                     String title = "Call Graph of " + project.getName() + " - " + methodPath;
+                    
+                    // Get background color from settings
+                    CallGraphSettings settings = CallGraphSettings.getInstance(project);
+                    String backgroundColor = settings.getCustomBackgroundColor();
+                    if (CallGraphSettings.BACKGROUND_TYPE_IDE.equals(settings.getBackgroundType())) {
+                        Color editorBackground = EditorColorsManager.getInstance().getGlobalScheme().getDefaultBackground();
+                        backgroundColor = "#" + ColorUtil.toHex(editorBackground);
+                    }
+                    
+                    // Replace title and background color in template
                     saveAsTemplate = saveAsTemplate.replace("${title}", title);
+                    saveAsTemplate = saveAsTemplate.replace("background: black;", "background: " + backgroundColor + ";");
+                    
+                    // Add network update script
                     saveAsTemplate += "<script>updateNetwork(" + CallGraphGenerator.getInstance(project).getJson() + ")</script>";
                     Utils.writeToFile(file.getPath() + "/callgraph_" + project.getName() + "_" + className + "_" + methodName + ".html", saveAsTemplate);
                 } catch (IOException e) {

--- a/src/main/java/callgraph/callgraph/settings/CallGraphSettings.java
+++ b/src/main/java/callgraph/callgraph/settings/CallGraphSettings.java
@@ -1,0 +1,68 @@
+package callgraph.callgraph.settings;
+
+import com.intellij.openapi.components.*;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Service for storing and retrieving user settings for Call Graph plugin.
+ * Settings are stored per-project.
+ */
+@Service(Service.Level.PROJECT)
+@State(
+        name = "CallGraphSettings",
+        storages = {@Storage("callgraph-settings.xml")}
+)
+public class CallGraphSettings implements PersistentStateComponent<CallGraphSettings> {
+    public static final String BACKGROUND_TYPE_CUSTOM = "custom";
+    public static final String BACKGROUND_TYPE_IDE = "ide";
+    
+    // Default settings
+    private String backgroundType = BACKGROUND_TYPE_CUSTOM;
+    private String customBackgroundColor = "#000000"; // Default to black
+
+    public static CallGraphSettings getInstance(Project project) {
+        return project.getService(CallGraphSettings.class);
+    }
+
+    @Nullable
+    @Override
+    public CallGraphSettings getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(@NotNull CallGraphSettings state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+
+    public String getBackgroundType() {
+        return backgroundType;
+    }
+
+    public void setBackgroundType(String backgroundType) {
+        this.backgroundType = backgroundType;
+    }
+
+    public String getCustomBackgroundColor() {
+        return customBackgroundColor;
+    }
+
+    public void setCustomBackgroundColor(String customBackgroundColor) {
+        this.customBackgroundColor = customBackgroundColor;
+    }
+
+    /**
+     * Get the effective background color based on current settings.
+     * @param ideEditorBackgroundColor The IDE editor background color
+     * @return The background color to use
+     */
+    public String getEffectiveBackgroundColor(String ideEditorBackgroundColor) {
+        if (BACKGROUND_TYPE_IDE.equals(backgroundType)) {
+            return ideEditorBackgroundColor;
+        }
+        return customBackgroundColor;
+    }
+}

--- a/src/main/java/callgraph/callgraph/settings/CallGraphSettingsDialog.java
+++ b/src/main/java/callgraph/callgraph/settings/CallGraphSettingsDialog.java
@@ -1,0 +1,253 @@
+package callgraph.callgraph.settings;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.ui.ColorUtil;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.components.JBRadioButton;
+import com.intellij.util.ui.JBUI;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/**
+ * Dialog for configuring CallGraph plugin settings.
+ */
+public class CallGraphSettingsDialog extends DialogWrapper {
+    private final CallGraphSettings settings;
+    private final Project project;
+    
+    private JBRadioButton useCustomColorButton;
+    private JBRadioButton useIdeColorButton;
+    private JButton colorPickerButton;
+    private JPanel colorPreview;
+    
+    private String selectedBackgroundType;
+    private String selectedCustomColor;
+    
+    // Store original settings to revert if canceled
+    private final String originalBackgroundType;
+    private final String originalCustomColor;
+    
+    /**
+     * Listener for real-time settings changes
+     */
+    public interface SettingsChangeListener {
+        void onSettingsChanged(String backgroundType, String customBackgroundColor);
+    }
+    
+    private SettingsChangeListener changeListener;
+
+    public CallGraphSettingsDialog(Project project) {
+        super(project, true);
+        this.project = project;
+        this.settings = CallGraphSettings.getInstance(project);
+        
+        // Store original settings for cancel action
+        this.originalBackgroundType = settings.getBackgroundType();
+        this.originalCustomColor = settings.getCustomBackgroundColor();
+        
+        // Initialize current working values
+        this.selectedBackgroundType = this.originalBackgroundType;
+        this.selectedCustomColor = this.originalCustomColor;
+        
+        // Set the change listener to update the browser in real-time
+        this.changeListener = (backgroundType, customBackgroundColor) -> {
+            // Apply changes immediately
+            settings.setBackgroundType(backgroundType);
+            settings.setCustomBackgroundColor(customBackgroundColor);
+            callgraph.callgraph.browser.BrowserManager.getInstance(project).applySettings();
+        };
+        
+        setTitle("Call Graph Settings");
+        init();
+    }
+
+    @Nullable
+    @Override
+    protected JComponent createCenterPanel() {
+        JPanel dialogPanel = new JPanel(new BorderLayout());
+        dialogPanel.setPreferredSize(new Dimension(400, 180));  // Reduce size for more compact dialog
+        
+        // Create tabs panel for future expansion
+        JTabbedPane tabbedPane = new JTabbedPane();
+        
+        // Appearance tab
+        JPanel appearancePanel = createAppearancePanel();
+        tabbedPane.addTab("Appearance", appearancePanel);
+        
+        dialogPanel.add(tabbedPane, BorderLayout.CENTER);
+        
+        return dialogPanel;
+    }
+
+    private JPanel createAppearancePanel() {
+        JPanel panel = new JPanel(new GridBagLayout());
+        panel.setBorder(JBUI.Borders.empty(5));
+        
+        GridBagConstraints c = new GridBagConstraints();
+        c.gridx = 0;
+        c.gridy = 0;
+        c.gridwidth = GridBagConstraints.REMAINDER;
+        c.fill = GridBagConstraints.HORIZONTAL;
+        c.anchor = GridBagConstraints.NORTHWEST;
+        c.weightx = 1.0;
+        
+        // Background color section
+        JPanel backgroundPanel = new JPanel(new GridBagLayout());
+        backgroundPanel.setBorder(BorderFactory.createTitledBorder(
+                BorderFactory.createEtchedBorder(), "Background Color", 
+                TitledBorder.LEFT, TitledBorder.TOP));
+        
+        ButtonGroup backgroundGroup = new ButtonGroup();
+        
+        // Create the radio buttons for background type selection
+        useIdeColorButton = new JBRadioButton("Use IDE Editor Background");
+        useIdeColorButton.setSelected(CallGraphSettings.BACKGROUND_TYPE_IDE.equals(selectedBackgroundType));
+        backgroundGroup.add(useIdeColorButton);
+        
+        useCustomColorButton = new JBRadioButton("Use Custom Color");
+        useCustomColorButton.setSelected(CallGraphSettings.BACKGROUND_TYPE_CUSTOM.equals(selectedBackgroundType));
+        backgroundGroup.add(useCustomColorButton);
+        
+        // Color picker panel with color preview
+        JPanel colorPickerPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
+        colorPickerButton = new JButton("Choose Color...");
+        
+        colorPreview = new JPanel();
+        colorPreview.setPreferredSize(new Dimension(24, 24));
+        colorPreview.setBorder(BorderFactory.createLineBorder(JBColor.GRAY));
+        updateColorPreview();
+        
+        colorPickerButton.addActionListener(e -> {
+            Color initialColor;
+            try {
+                initialColor = Color.decode(selectedCustomColor);
+            } catch (NumberFormatException ex) {
+                initialColor = Color.BLACK;
+            }
+            
+            // Use JColorChooser directly instead of ColorChooserService
+            Color color = JColorChooser.showDialog(panel, "Choose Background Color", initialColor);
+            
+            if (color != null) {
+                selectedCustomColor = "#" + ColorUtil.toHex(color);
+                updateColorPreview();
+                // Automatically select custom color radio button
+                useCustomColorButton.setSelected(true);
+                selectedBackgroundType = CallGraphSettings.BACKGROUND_TYPE_CUSTOM;
+                
+                // Notify changes to update the UI immediately
+                if (changeListener != null) {
+                    changeListener.onSettingsChanged(selectedBackgroundType, selectedCustomColor);
+                }
+            }
+        });
+        
+        colorPickerPanel.add(colorPickerButton);
+        colorPickerPanel.add(colorPreview);
+        
+        // Layout components with compact organization
+        GridBagConstraints bc = new GridBagConstraints();
+        bc.gridx = 0;
+        bc.gridy = 0;
+        bc.anchor = GridBagConstraints.WEST;
+        bc.insets = JBUI.insets(3, 3, 1, 3);
+        bc.fill = GridBagConstraints.HORIZONTAL;
+        backgroundPanel.add(useIdeColorButton, bc);
+        
+        bc.gridx = 0;
+        bc.gridy = 1;
+        bc.insets = JBUI.insets(1, 3, 1, 3);
+        backgroundPanel.add(useCustomColorButton, bc);
+        
+        bc.gridx = 0;
+        bc.gridy = 2;
+        bc.insets = JBUI.insets(0, 20, 3, 3); // Indent the color picker
+        backgroundPanel.add(colorPickerPanel, bc);
+        
+        panel.add(backgroundPanel, c);
+        
+        // Setup action listeners for radio buttons
+        ActionListener radioListener = actionEvent -> {
+            if (useCustomColorButton.isSelected()) {
+                selectedBackgroundType = CallGraphSettings.BACKGROUND_TYPE_CUSTOM;
+                colorPickerButton.setEnabled(true);
+            } else {
+                selectedBackgroundType = CallGraphSettings.BACKGROUND_TYPE_IDE;
+                colorPickerButton.setEnabled(false);
+            }
+            
+            // Notify listener about the change to update the UI immediately
+            if (changeListener != null) {
+                changeListener.onSettingsChanged(selectedBackgroundType, selectedCustomColor);
+            }
+        };
+        
+        useCustomColorButton.addActionListener(radioListener);
+        useIdeColorButton.addActionListener(radioListener);
+        
+        // Initialize enabled state
+        colorPickerButton.setEnabled(useCustomColorButton.isSelected());
+        
+        return panel;
+    }
+    
+    private void updateColorPreview() {
+        try {
+            colorPreview.setBackground(Color.decode(selectedCustomColor));
+        } catch (NumberFormatException e) {
+            colorPreview.setBackground(Color.BLACK);
+        }
+    }
+
+    @Override
+    protected void doOKAction() {
+        // Final save of settings (should be same as current state since we apply changes immediately)
+        settings.setBackgroundType(selectedBackgroundType);
+        settings.setCustomBackgroundColor(selectedCustomColor);
+        super.doOKAction();
+    }
+
+    public void resetToOriginal() {
+        // Reset stored values to original values
+        selectedBackgroundType = originalBackgroundType;
+        selectedCustomColor = originalCustomColor;
+        
+        // Reset UI to match original values
+        useIdeColorButton.setSelected(CallGraphSettings.BACKGROUND_TYPE_IDE.equals(originalBackgroundType));
+        useCustomColorButton.setSelected(CallGraphSettings.BACKGROUND_TYPE_CUSTOM.equals(originalBackgroundType));
+        colorPickerButton.setEnabled(CallGraphSettings.BACKGROUND_TYPE_CUSTOM.equals(originalBackgroundType));
+        updateColorPreview();
+        
+        // Apply original settings
+        settings.setBackgroundType(originalBackgroundType);
+        settings.setCustomBackgroundColor(originalCustomColor);
+        callgraph.callgraph.browser.BrowserManager.getInstance(project).applySettings();
+    }
+
+    @Override
+    protected Action @NotNull [] createActions() {
+        Action[] defaultActions = super.createActions();
+        
+        // Replace the cancel action with a new action named "Reset"
+        for (int i = 0; i < defaultActions.length; i++) {
+            if (defaultActions[i] == getCancelAction()) {
+                defaultActions[i] = new DialogWrapperAction("Reset") {
+                    @Override
+                    protected void doAction(ActionEvent e) {
+                        resetToOriginal();
+                    }
+                };
+                break;
+            }
+        }
+        
+        return defaultActions;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -70,6 +70,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow id="CallGraph" icon="AllIcons.Hierarchy.Subtypes" anchor="bottom"
                     factoryClass="callgraph.callgraph.CallGraphToolWindowFactory"/>
+        <projectService serviceImplementation="callgraph.callgraph.settings.CallGraphSettings"/>
     </extensions>
     
     <actions>


### PR DESCRIPTION
This pull request introduces a new settings feature for the Call Graph plugin, allowing users to customize the graph's background color through a settings dialog. It includes changes to the frontend, backend, and plugin configuration to support this functionality. The most important changes are grouped below by theme.

### Frontend Enhancements:
* Added an "OPTIONS" button to the HTML interface to open the settings dialog (`src/main/frontend/src/html/callgraph.html`).
* Introduced a new `openSettings` method in the `JavaBridge` object to handle the settings dialog invocation (`src/main/frontend/src/js/callgraph.js`).

### Backend Enhancements:
* Added a `CallGraphSettings` service to store user preferences, including background color and type (`src/main/java/callgraph/callgraph/settings/CallGraphSettings.java`).
* Implemented an `OpenSettingsHandler` to open the settings dialog from the UI (`src/main/java/callgraph/callgraph/browser/handlers/OpenSettingsHandler.java`).
* Modified the `BrowserManager` class to apply background color settings to the browser display and ensure settings are applied after the browser is initialized (`src/main/java/callgraph/callgraph/browser/BrowserManager.java`). [[1]](diffhunk://#diff-30f91eeda73f24795e040a662dd2bd96845262385b0b19cb2d6013d5bde75126R105-R124) [[2]](diffhunk://#diff-30f91eeda73f24795e040a662dd2bd96845262385b0b19cb2d6013d5bde75126R136-R138)

### Settings Dialog:
* Created a `CallGraphSettingsDialog` to provide a user interface for configuring the graph's appearance, including options for custom or IDE-based background colors (`src/main/java/callgraph/callgraph/settings/CallGraphSettingsDialog.java`).

### Plugin Configuration:
* Registered the `CallGraphSettings` service in the plugin's `plugin.xml` file (`src/main/resources/META-INF/plugin.xml`).